### PR TITLE
fix: change deprecated set-env in github actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Extract version
-        run: echo "::set-env name=APP_VERSION::$(jq -r '.version' package.json)"
+        run: echo "APP_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_ENV
 
       - name: Build image
         run: docker build -t rezoleo/github-project-automation:${APP_VERSION} .


### PR DESCRIPTION
The new way to set an env var is defined here:
https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable